### PR TITLE
Feature/bind once

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -30,4 +30,4 @@ config :medusa, Medusa,
 # Configuration from the imported file will override the ones defined
 # here (which is why it is important to import them last).
 #
-#     import_config "#{Mix.env}.exs"
+import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+config :logger, level: :warn

--- a/lib/medusa.ex
+++ b/lib/medusa.ex
@@ -71,6 +71,7 @@ defmodule Medusa do
 
   def consume(route, function, opts \\ []) do
     {_, 1} =  :erlang.fun_info(function, :arity)
+
     # Register an route on the Broker
     Medusa.Broker.new_route(route)
 

--- a/lib/medusa.ex
+++ b/lib/medusa.ex
@@ -74,28 +74,12 @@ defmodule Medusa do
     # Register an route on the Broker
     Medusa.Broker.new_route(route)
 
-    # Can't use PID here, because we need to register by name.
-    producer = Medusa.Supervisors.Producers.start_child(route)
-    opts = build_exit_strategy opts, producer
+    Medusa.Supervisors.Producers.start_child(route)
     Medusa.Supervisors.Consumers.start_child(function, route, opts)
   end
 
   def publish(event, payload, metadata \\ %{}) do
     Medusa.Broker.publish event, payload, metadata
-  end
-
-  defp build_exit_strategy(opts, producer_start_result) do
-    build_exit_strategy opts[:bind_once], opts, producer_start_result
-  end
-
-  defp build_exit_strategy(true, opts, {:ok, pid}) do
-    Keyword.put opts, :bind_once, :full
-  end
-  defp build_exit_strategy(true, opts, {:error, {:already_started, pid}}) do
-    Keyword.put opts, :bind_once, :only_consumer
-  end
-  defp build_exit_strategy(_, opts, _) do
-    opts
   end
 
 end

--- a/lib/medusa/broker.ex
+++ b/lib/medusa/broker.ex
@@ -1,5 +1,6 @@
 defmodule Medusa.Broker do
   @moduledoc false
+  alias Experimental.GenStage
   use GenServer
   require Logger
 
@@ -28,6 +29,16 @@ defmodule Medusa.Broker do
   def publish(event, payload, metadata \\ %{}) do
     message = %Message{body: payload, metadata: metadata}
     GenServer.cast(__MODULE__, {:publish, event, message})
+  end
+
+  @doc """
+  Send exit signal to producer route name.
+  """
+  def exit_producer(route) do
+    case Process.whereis(route) do
+      nil -> :ok
+      pid when is_pid(pid) -> GenStage.cast pid, :exit
+    end
   end
 
   # Callbacks

--- a/lib/medusa/broker.ex
+++ b/lib/medusa/broker.ex
@@ -1,6 +1,5 @@
 defmodule Medusa.Broker do
   @moduledoc false
-  alias Experimental.GenStage
   use GenServer
   require Logger
 
@@ -29,16 +28,6 @@ defmodule Medusa.Broker do
   def publish(event, payload, metadata \\ %{}) do
     message = %Message{body: payload, metadata: metadata}
     GenServer.cast(__MODULE__, {:publish, event, message})
-  end
-
-  @doc """
-  Send exit signal to producer route name.
-  """
-  def exit_producer(route) do
-    case Process.whereis(route) do
-      nil -> :ok
-      pid when is_pid(pid) -> GenStage.cast pid, :exit
-    end
   end
 
   # Callbacks

--- a/lib/medusa/consumer.ex
+++ b/lib/medusa/consumer.ex
@@ -1,31 +1,47 @@
 defmodule Medusa.Consumer do
   alias Experimental.GenStage
+  alias Medusa.Broker
   use GenStage
   require Logger
 
-  def start_link(args1, args2) do
-    Logger.debug "Starting Consumer for: #{inspect args1}. #{inspect args2}"
-    GenStage.start_link __MODULE__, [args1, args2]
+  def start_link(args) do
+    Logger.debug "Starting Consumer for: #{inspect args}"
+    params = %{
+      function: Keyword.fetch!(args, :function),
+      to_link: Keyword.fetch!(args, :to_link),
+      opts: Keyword.get(args, :opts, [])
+   }
+    GenStage.start_link __MODULE__, params
   end
 
-  def init([{:function, f}, {:to_link, to_link}]) do
-    {:consumer, f, subscribe_to: [to_link]}
+  def init(%{function: f, to_link: link, opts: opts} = params) do
+    {:consumer, params, subscribe_to: [link]}
   end
 
   @doc """
   Process the event passing the argument to the function.
   """
-  def handle_events(event, _from, state) do
-    Logger.debug "Received event: #{inspect event}"
-    event = List.flatten(event)
-    unless (event |> Enum.empty?) do
-      Enum.each(event,
-        fn e -> result = state.(e)
-        Logger.debug "Result of computation: #{inspect result}"
-      end)
-    end
-    # We are a consumer, so we never emit events.
+  def handle_events(events, _from, state) do
+    Logger.debug "Received event: #{inspect events}"
+    events
+    |> List.flatten
+    |> do_handle_events(state)
+  end
+
+  defp do_handle_events([], state) do
     {:noreply, [], state}
+  end
+  defp do_handle_events(events, %{function: f, opts: opts} = state) do
+    Enum.each(events, &f.(&1))
+    case opts[:bind_once] do
+      :full ->
+        Broker.exit_producer state.to_link
+        {:stop, :bind_once, state}
+      :only_consumer ->
+        {:stop, :bind_once, state}
+      _ ->
+        {:noreply, [], state}
+    end
   end
 
 end

--- a/lib/medusa/producer.ex
+++ b/lib/medusa/producer.ex
@@ -15,6 +15,10 @@ defmodule Medusa.Producer do
     {:producer, state, dispatcher: GenStage.BroadcastDispatcher}
   end
 
+  def handle_cast(:exit, state) do
+    {:stop, :bind_once, state}
+  end
+
   def handle_demand(demand, state) do
     Logger.debug "Current demand: #{inspect demand}."
     get_next(%{state | demand: demand})

--- a/lib/medusa/supervisors/consumers.ex
+++ b/lib/medusa/supervisors/consumers.ex
@@ -14,8 +14,8 @@ defmodule Medusa.Supervisors.Consumers do
     supervise(children, strategy: :simple_one_for_one)
   end
 
-  def start_child(f, to_link) do
+  def start_child(f, to_link, opts \\ []) do
     to_link = String.to_atom to_link
-    Supervisor.start_child(__MODULE__, [function: f, to_link: to_link])
+    Supervisor.start_child(__MODULE__, [[function: f, to_link: to_link, opts: opts]])
   end
 end

--- a/test/external_integration_test.exs
+++ b/test/external_integration_test.exs
@@ -1,6 +1,20 @@
+defmodule MyModule do
+  def echo(message) do
+    message = put_in message, [Access.key(:metadata), :from], MyModule.Echo
+    send message.metadata.to, message
+  end
+
+  def ping(message) do
+    message = put_in message, [Access.key(:metadata), :from], MyModule.Ping
+    send message.metadata.to, message
+  end
+end
+
 defmodule ExternalIntegrationTest do
   use ExUnit.Case
   require Medusa
+
+  alias Medusa.Broker.Message
 
   setup do
     fc = fn x -> send(:test, {:hey, "You sent me", x}) end
@@ -24,8 +38,36 @@ defmodule ExternalIntegrationTest do
     Medusa.publish "foo.bar", 90, %{"optional_field" => "nice_to_have"}
 
     # We should receive two because of the routes setup.
-    assert_receive {:hey, "You sent me", %Medusa.Broker.Message{body: 90, metadata: %{"optional_field" => "nice_to_have"}}}
-    assert_receive {:hey, "You sent me", %Medusa.Broker.Message{body: 90, metadata: %{"optional_field" => "nice_to_have"}}}
+    assert_receive {:hey, "You sent me", %Message{body: 90, metadata: %{"optional_field" => "nice_to_have"}}}
+    assert_receive {:hey, "You sent me", %Message{body: 90, metadata: %{"optional_field" => "nice_to_have"}}}
+  end
+
+  test "Send event to consumer with bind_once: true.
+        consumer and producer should die" do
+    assert {:ok, pid} = Medusa.consume "you.me", &MyModule.echo/1, bind_once: true
+    assert Process.alive?(pid)
+    assert producer = Process.whereis(:"you.me")
+    Medusa.publish "you.me", 100, %{to: self}
+    assert_receive %Message{body: 100, metadata: %{to: self, from: MyModule.Echo}}
+    Process.sleep(10) # wait producer and consumer die
+    refute Process.alive?(pid)
+    refute Process.alive?(producer)
+  end
+
+  test "Send event to consumer with bind_once: true.
+        But route is shared with others then producer should not die" do
+    assert {:ok, pid1} = Medusa.consume "me.you", &MyModule.ping/1
+    assert {:ok, pid2} = Medusa.consume "me.you", &MyModule.echo/1, bind_once: true
+    assert Process.alive?(pid1)
+    assert Process.alive?(pid2)
+    assert producer = Process.whereis(:"me.you")
+    Medusa.publish "me.you", 1000, %{to: self}
+    assert_receive %Message{body: 1000, metadata: %{to: self, from: MyModule.Echo}}
+    assert_receive %Message{body: 1000, metadata: %{to: self, from: MyModule.Ping}}
+    Process.sleep(10) # wait consumer bind_once die
+    assert Process.alive?(pid1)
+    refute Process.alive?(pid2)
+    assert Process.alive?(producer)
   end
 
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,1 @@
-Medusa.start "", ""
 ExUnit.start()


### PR DESCRIPTION
add Medusa.consume/3 with :bind_once options

- Consumer with bind_once will exit after process an event.
- Producer with only bind_once Consumer will also exit but not exit if has other Consumer.