### PR TITLE
Enforce arity of callback in consume

### DIFF
--- a/lib/medusa.ex
+++ b/lib/medusa.ex
@@ -70,6 +70,8 @@ defmodule Medusa do
   end
 
   def consume(route, function) do
+    {_, 1} =  :erlang.fun_info(function, :arity)
+
     # Register an route on the Broker
     Medusa.Broker.new_route(route)
 

--- a/test/external_integration_test.exs
+++ b/test/external_integration_test.exs
@@ -11,6 +11,11 @@ defmodule ExternalIntegrationTest do
     assert {:ok, _pid} = Medusa.consume "foo.bob", ctx[:fc]
   end
 
+  test "Add invalid consumer", ctx do
+    assert_raise MatchError, ~r/arity/, fn -> Medusa.consume "foo.bob", fn -> IO.puts("blah") end end
+  end
+
+
   test "Send events", ctx do
     Process.register self, :test
     Medusa.consume "foo.bar", ctx[:fc]


### PR DESCRIPTION
Could probably use a better exception, but will stop mistakes for now.