### PR TITLE
Adapter rabbitmq

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -8,9 +8,6 @@ use Mix.Config
 # if you want to provide default values for your application for
 # 3rd-party users, it should be done in your "mix.exs" file.
 
-config :medusa, Medusa,
-        adapter: Medusa.Adapter.Local
-
 # You can configure for your application as:
 #
 #     config :medusa, key: :value

--- a/lib/medusa.ex
+++ b/lib/medusa.ex
@@ -1,6 +1,10 @@
 defmodule Medusa do
   use Application
   require Logger
+  import Supervisor.Spec, warn: false
+
+  @available_adapters ~w(Medusa.Adapter.Local)
+  @default_adapter Medusa.Adapter.Local
 
   @moduledoc """
   Medusa is a Pub/Sub system that leverages GenStage.
@@ -25,48 +29,18 @@ defmodule Medusa do
 
   """
 
-  @misconfiguration_error """
-    Oops... looks like Medusa is not configured.
-    Please, check if you have a line like this in your configuration:
-
-    config :medusa, Medusa,
-            adapter: Medusa.Adapter.Local
-
-    Medusa has support for other adapers. Check them in Hex.
-    Don't worry, she will not turn you into stone... yet.
-  """
-
-
-  # Check if configuration exists.
-  # unless Application.get_env(:medusa, Medusa) do
-  #   raise @misconfiguration_error
-  # end
-
-  # unless Keyword.get(Application.get_env(:medusa, Medusa), :adapter) do
-  #   raise @misconfiguration_error
-  # end
-
-
   def start(_type, _args) do
-    import Supervisor.Spec, warn: false
-
+    ensure_config_correct()
     children = [
       worker(Medusa.Broker, []),
+      child_adapter(),
       supervisor(Task.Supervisor, [[name: Broker.Supervisor]]),
       supervisor(Medusa.Supervisors.Producers, []),
       supervisor(Medusa.Supervisors.Consumers, [])
-    ] |> start_local_adapter_if_configured
+    ]
 
     opts = [strategy: :one_for_one, name: Medusa.Supervisor]
     Supervisor.start_link(children, opts)
-  end
-
-  def start_local_adapter_if_configured(children) do
-    import Supervisor.Spec, warn: false
-
-    if Keyword.get(Application.get_env(:medusa, Medusa), :adapter) == Medusa.Adapter.Local do
-      [worker(Medusa.Adapter.Local, []) | children]
-    end
   end
 
   def consume(route, function, opts \\ []) do
@@ -81,6 +55,25 @@ defmodule Medusa do
 
   def publish(event, payload, metadata \\ %{}) do
     Medusa.Broker.publish event, payload, metadata
+  end
+
+  defp child_adapter do
+    :medusa
+    |> Application.get_env(Medusa)
+    |> Keyword.fetch!(:adapter)
+    |> worker([])
+  end
+
+  defp ensure_config_correct do
+    app_config = Application.get_env(:medusa, Medusa, [])
+    adapter = Keyword.get(app_config, :adapter)
+    cond do
+      adapter in @available_adapters ->
+        :ok
+      true ->
+        new_app_config = Keyword.merge(app_config, [adapter: @default_adapter])
+        Application.put_env(:medusa, Medusa, new_app_config, persistent: true)
+    end
   end
 
 end

--- a/lib/medusa/adapter.ex
+++ b/lib/medusa/adapter.ex
@@ -5,8 +5,9 @@ defmodule Medusa.Adapter do
   The objective of having this adapter is to be able to switch them if
   you have specific requirements, such as: using Redis, RabbitMQ, AQMP.
   """
+  alias Medusa.Broker.Message
 
-  @callback insert(type :: String.t, payload :: any) :: :ok | :error
-  @callback next(type :: String.t) :: [] | [any]
+  @callback new_route(event :: String.t) :: :ok | :error
+  @callback publish(event :: String.t, message :: Message) :: :ok | :error
 
 end

--- a/lib/medusa/adapter.ex
+++ b/lib/medusa/adapter.ex
@@ -1,13 +1,9 @@
 defmodule Medusa.Adapter do
   @moduledoc """
-  Behaviour for creating event queue adapters.
+  Behaviour for broker to communicate with Queue
 
   The objective of having this adapter is to be able to switch them if
   you have specific requirements, such as: using Redis, RabbitMQ, AQMP.
-
-  By default Medusa leverages Erlang's `:queue` module for each type of
-  event.
-
   """
 
   @callback insert(type :: String.t, payload :: any) :: :ok | :error

--- a/lib/medusa/adapter/local.ex
+++ b/lib/medusa/adapter/local.ex
@@ -1,31 +1,23 @@
 defmodule Medusa.Adapter.Local do
   @moduledoc false
+  @behaviour Medusa.Adapter
   use GenServer
   require Logger
-  alias Medusa.{Broker.Message, Queue}
+  alias Medusa.Broker
 
-  # API
   def start_link() do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 
   def new_route(event) do
-    broadcast(get_all_members, {:new_route, event})
+    GenServer.call(__MODULE__, {:new_route, event})
   end
 
   def publish(event, message) do
-    broadcast(get_members, {:publish, event, message})
+    GenServer.cast(__MODULE__, {:publish, event, message})
   end
 
-  # Callbacks
-
-  @doc """
-  Register self into pg2 group. see `pg2_namespace/0`
-  """
   def init(_opts) do
-    group = pg2_namespace
-    :ok = :pg2.create group
-    :ok = :pg2.join group, self
     {:ok, MapSet.new}
   end
 
@@ -34,92 +26,9 @@ defmodule Medusa.Adapter.Local do
     {:reply, :ok, MapSet.put(state, event)}
   end
 
-  def handle_call({:publish, event, payload}, _from, state) do
+  def handle_cast({:publish, event, payload}, state) do
     Logger.debug "#{inspect __MODULE__}: [#{inspect event}]: #{inspect payload}"
-    Enum.each(state, &maybe_route {&1, event, payload})
-    {:reply, :ok, state}
-  end
-
-  def handle_info({:forward_to_local, msg}, state) do
-    handle_call(msg, self, state)
+    Enum.each(state, &Broker.maybe_route({&1, event, payload}))
     {:noreply, state}
   end
-
-  defp maybe_route({route, event, payload}) do
-    f = fn -> maybe_route route, event, payload end
-    Task.Supervisor.start_child Broker.Supervisor, f
-  end
-
-  defp maybe_route(route, event, payload) do
-    if route_match?(route, event) do
-      enqueue route, payload
-      trigger_producer route
-    end
-  end
-
-  defp enqueue(route, payload) do
-    Queue.insert route, payload
-  end
-
-  defp trigger_producer(route) do
-    route
-    |> String.to_atom
-    |> GenServer.cast({:trigger})
-  end
-
-  defp route_match?(route, incoming)
-  when is_binary(route) and is_binary(incoming) do
-    route = String.split route, "."
-    incoming = String.split incoming, "."
-    route_match? route, incoming
-  end
-  defp route_match?([], []), do: true
-  defp route_match?(["*"|t1], [_|t2]), do: route_match?(t1, t2)
-  defp route_match?([h|t1], [h|t2]), do: route_match?(t1, t2)
-  defp route_match?(_, _), do: false
-
-  # process group name
-  defp pg2_namespace do
-    name =
-      :medusa
-      |> Application.get_env(Medusa)
-      |> Keyword.get(:group, random_name)
-    {:medusa, name}
-  end
-
-  # random name
-  defp random_name(len \\ 32) do
-    len
-    |> :crypto.strong_rand_bytes
-    |> Base.url_encode64
-    |> binary_part(0, len)
-  end
-
-  defp broadcast(pids, msg) when is_list(pids) do
-    pids
-    |> List.flatten
-    |> Enum.each(fn
-      pid when is_pid(pid) and node(pid) == node() ->
-        GenServer.call __MODULE__, msg
-      pid ->
-        send pid, {:forward_to_local, msg}
-    end)
-  end
-
-  # get all nodes in medusa
-  defp get_all_members do
-    :pg2.which_groups
-    |> Enum.filter_map(&elem(&1, 0) == :medusa, &:pg2.get_members/1)
-  end
-
-  # get all medusa groups and random one member from each group
-  defp get_members do
-    get_all_members
-    |> Enum.map(&random_member/1)
-  end
-
-  defp random_member([]), do: []
-  defp random_member([pid]), do: pid
-  defp random_member(pids) when is_list(pids), do: Enum.random pids
-
 end

--- a/lib/medusa/adapter/local.ex
+++ b/lib/medusa/adapter/local.ex
@@ -5,7 +5,7 @@ defmodule Medusa.Adapter.Local do
   require Logger
   alias Medusa.Broker
 
-  def start_link() do
+  def start_link do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 

--- a/lib/medusa/adapter/local.ex
+++ b/lib/medusa/adapter/local.ex
@@ -1,39 +1,125 @@
 defmodule Medusa.Adapter.Local do
+  @moduledoc false
   use GenServer
-  @behaviour Medusa.Adapter
   require Logger
+  alias Medusa.{Broker.Message, Queue}
 
+  # API
   def start_link() do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 
-  def insert(type, payload) do
-    Logger.debug "#{inspect __MODULE__}: insert #{inspect payload} on #{inspect type}"
-    GenServer.cast __MODULE__, {:insert, type, payload}
+  def new_route(event) do
+    broadcast(get_all_members, {:new_route, event})
   end
 
-  def next(type) do
-    Logger.debug "#{inspect __MODULE__}: next from #{inspect type}"
-    GenServer.call __MODULE__, {:next, type}
+  def publish(event, message) do
+    broadcast(get_members, {:publish, event, message})
   end
 
-  def init(_args) do
-    {:ok, %{}}
+  # Callbacks
+
+  @doc """
+  Register self into pg2 group. see `pg2_namespace/0`
+  """
+  def init(_opts) do
+    group = pg2_namespace
+    :ok = :pg2.create group
+    :ok = :pg2.join group, self
+    {:ok, MapSet.new}
   end
 
-  def handle_call({:next, type}, _from, state) do
-    case Map.get(state, type) do
-      :nil -> {:reply, [], state}
-      q ->
-        case :queue.out q do
-          {{:value, i}, q} -> {:reply, i, Map.put(state, type, q)}
-          {:empty, q} -> {:reply, [], Map.put(state, type, q)}
-        end
+  def handle_call({:new_route, event}, _from, state) do
+    Logger.debug "#{inspect __MODULE__}: [#{inspect event}]"
+    {:reply, :ok, MapSet.put(state, event)}
+  end
+
+  def handle_call({:publish, event, payload}, _from, state) do
+    Logger.debug "#{inspect __MODULE__}: [#{inspect event}]: #{inspect payload}"
+    Enum.each(state, &maybe_route {&1, event, payload})
+    {:reply, :ok, state}
+  end
+
+  def handle_info({:forward_to_local, msg}, state) do
+    handle_call(msg, self, state)
+    {:noreply, state}
+  end
+
+  defp maybe_route({route, event, payload}) do
+    f = fn -> maybe_route route, event, payload end
+    Task.Supervisor.start_child Broker.Supervisor, f
+  end
+
+  defp maybe_route(route, event, payload) do
+    if route_match?(route, event) do
+      enqueue route, payload
+      trigger_producer route
     end
   end
 
-  def handle_cast({:insert, type, payload}, state) do
-    {:noreply, Map.update(state, type, :queue.in(payload, :queue.new), fn q -> :queue.in(payload, q) end)}
+  defp enqueue(route, payload) do
+    Queue.insert route, payload
   end
+
+  defp trigger_producer(route) do
+    route
+    |> String.to_atom
+    |> GenServer.cast({:trigger})
+  end
+
+  defp route_match?(route, incoming)
+  when is_binary(route) and is_binary(incoming) do
+    route = String.split route, "."
+    incoming = String.split incoming, "."
+    route_match? route, incoming
+  end
+  defp route_match?([], []), do: true
+  defp route_match?(["*"|t1], [_|t2]), do: route_match?(t1, t2)
+  defp route_match?([h|t1], [h|t2]), do: route_match?(t1, t2)
+  defp route_match?(_, _), do: false
+
+  # process group name
+  defp pg2_namespace do
+    name =
+      :medusa
+      |> Application.get_env(Medusa)
+      |> Keyword.get(:group, random_name)
+    {:medusa, name}
+  end
+
+  # random name
+  defp random_name(len \\ 32) do
+    len
+    |> :crypto.strong_rand_bytes
+    |> Base.url_encode64
+    |> binary_part(0, len)
+  end
+
+  defp broadcast(pids, msg) when is_list(pids) do
+    pids
+    |> List.flatten
+    |> Enum.each(fn
+      pid when is_pid(pid) and node(pid) == node() ->
+        GenServer.call __MODULE__, msg
+      pid ->
+        send pid, {:forward_to_local, msg}
+    end)
+  end
+
+  # get all nodes in medusa
+  defp get_all_members do
+    :pg2.which_groups
+    |> Enum.filter_map(&elem(&1, 0) == :medusa, &:pg2.get_members/1)
+  end
+
+  # get all medusa groups and random one member from each group
+  defp get_members do
+    get_all_members
+    |> Enum.map(&random_member/1)
+  end
+
+  defp random_member([]), do: []
+  defp random_member([pid]), do: pid
+  defp random_member(pids) when is_list(pids), do: Enum.random pids
 
 end

--- a/lib/medusa/adapter/pg2.ex
+++ b/lib/medusa/adapter/pg2.ex
@@ -10,7 +10,7 @@ defmodule Medusa.Adapter.PG2 do
   end
 
   def new_route(event) do
-    broadcast(get_all_members, {:new_route, event})
+    GenServer.call(__MODULE__, {:new_route, event})
   end
 
   def publish(event, message) do
@@ -39,7 +39,7 @@ defmodule Medusa.Adapter.PG2 do
   end
 
   def handle_info({:forward_to_local, msg}, state) do
-    handle_call(msg, self, state)
+    spawn(fn -> GenServer.call(__MODULE__, msg) end)
     {:noreply, state}
   end
 

--- a/lib/medusa/adapter/pg2.ex
+++ b/lib/medusa/adapter/pg2.ex
@@ -5,7 +5,7 @@ defmodule Medusa.Adapter.PG2 do
   require Logger
   alias Medusa.{Broker}
 
-  def start_link() do
+  def start_link do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 

--- a/lib/medusa/adapter/pg2.ex
+++ b/lib/medusa/adapter/pg2.ex
@@ -1,0 +1,90 @@
+defmodule Medusa.Adapter.PG2 do
+  @moduledoc false
+  @behaviour Medusa.Adapter
+  use GenServer
+  require Logger
+  alias Medusa.{Broker}
+
+  def start_link() do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def new_route(event) do
+    broadcast(get_all_members, {:new_route, event})
+  end
+
+  def publish(event, message) do
+    broadcast(get_members, {:publish, event, message})
+  end
+
+  @doc """
+  Register self into pg2 group. see `pg2_namespace/0`
+  """
+  def init(_opts) do
+    group = pg2_namespace()
+    :ok = :pg2.create(group)
+    :ok = :pg2.join(group, self)
+    {:ok, MapSet.new}
+  end
+
+  def handle_call({:new_route, event}, _from, state) do
+    Logger.debug "#{inspect __MODULE__}: [#{inspect event}]"
+    {:reply, :ok, MapSet.put(state, event)}
+  end
+
+  def handle_call({:publish, event, payload}, _from, state) do
+    Logger.debug "#{inspect __MODULE__}: [#{inspect event}]: #{inspect payload}"
+    Enum.each(state, &Broker.maybe_route({&1, event, payload}))
+    {:reply, :ok, state}
+  end
+
+  def handle_info({:forward_to_local, msg}, state) do
+    handle_call(msg, self, state)
+    {:noreply, state}
+  end
+
+  # process group name
+  defp pg2_namespace do
+    name =
+      :medusa
+      |> Application.get_env(Medusa)
+      |> Keyword.get(:group, random_name)
+    {:medusa, name}
+  end
+
+  # random name
+  defp random_name(len \\ 32) do
+    len
+    |> :crypto.strong_rand_bytes
+    |> Base.url_encode64
+    |> binary_part(0, len)
+  end
+
+  defp broadcast(pids, msg) when is_list(pids) do
+    pids
+    |> List.flatten
+    |> Enum.each(fn
+      pid when is_pid(pid) and node(pid) == node() ->
+        GenServer.call(__MODULE__, msg)
+      pid ->
+        send(pid, {:forward_to_local, msg})
+    end)
+  end
+
+  # get all nodes in medusa
+  defp get_all_members do
+    :pg2.which_groups
+    |> Enum.filter_map(&elem(&1, 0) == :medusa, &:pg2.get_members/1)
+  end
+
+  # get all medusa groups and random one member from each group
+  defp get_members do
+    get_all_members
+    |> Enum.map(&random_member/1)
+  end
+
+  defp random_member([]), do: []
+  defp random_member([pid]), do: pid
+  defp random_member(pids) when is_list(pids), do: Enum.random(pids)
+
+end

--- a/lib/medusa/adapter/rabbitmq.ex
+++ b/lib/medusa/adapter/rabbitmq.ex
@@ -1,0 +1,121 @@
+defmodule Medusa.Adapter.RabbitMQ do
+  @moduledoc false
+  @behaviour Medusa.Adapter
+  use GenServer
+  use AMQP
+  require Logger
+  alias Medusa.Broker
+
+  defstruct channel: nil, routes: MapSet.new
+
+  defmodule Message do
+    defstruct event: nil, message: nil
+  end
+
+  @exchange_name "medusa"
+
+  def start_link do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def new_route(event) do
+    GenServer.call(__MODULE__, {:new_route, event})
+  end
+
+  def publish(event, message) do
+    GenServer.call(__MODULE__, {:publish, event, message})
+  end
+
+  def init([]) do
+    connection = init_connection()
+    {:ok, connection}
+  end
+
+  def handle_call({:new_route, event}, _from, state) do
+    Logger.debug "#{inspect __MODULE__}: [#{inspect event}]"
+    new_state = Map.update(state,
+                           :routes,
+                           MapSet.new([event]),
+                           &(MapSet.put(&1, event)))
+    {:reply, :ok, new_state}
+  end
+
+  def handle_call({:publish, event, payload}, _from, state) do
+    Logger.debug "#{inspect __MODULE__}: [#{inspect event}]: #{inspect payload}"
+    message = %Message{event: event, message: payload} |> Poison.encode!
+    AMQP.Basic.publish(state.channel, @exchange_name, "", message)
+    {:noreply, state}
+  end
+
+  def handle_info({:basic_consume_ok, %{consumer_tag: consumer_tag}}, state) do
+    {:noreply, state}
+  end
+
+  def handle_info({:basic_cancel, %{consumer_tag: consumer_tag}}, state) do
+    {:stop, :normal, state}
+  end
+
+  def handle_info({:basic_cancel_ok, %{consumer_tag: consumer_tag}}, state) do
+    {:noreply, state}
+  end
+
+  def handle_info({:basic_deliver, payload, %{delivery_tag: tag}}, state) do
+    msg = Poison.decode!(payload)
+    event = Map.fetch!(msg, "event")
+    message = Map.fetch!(msg, "message")
+    message = %Broker.Message{body: message["body"], metadata: message["metadata"]}
+    Enum.each(state.routes, &Broker.maybe_route({&1, event, message}))
+    Basic.ack(state.channel, tag)
+    {:noreply, state}
+  end
+
+  def handle_info({:DOWN, _, :process, pid, reason}, %{channel: %{pid: pid, conn: conn}}) do
+     state =
+       case Process.alive?(conn.pid) do
+         true -> init_channel(conn)
+         false -> init_connection()
+       end
+    {:noreply, state}
+  end
+
+  def handle_info(msg, state) do
+    Logger.warn("Got unexpected message #{msg} state #{state} from #{self}")
+    {:noreply, state}
+  end
+
+  defp init_connection do
+    # FIXME connection url
+    case Connection.open do
+      {:ok, conn} ->
+        init_channel(conn)
+      {:error, error} ->
+        Process.sleep(10_000)
+        init_connection()
+    end
+  end
+
+  defp init_channel(conn) do
+    {:ok, chan} = Channel.open(conn)
+    Process.monitor(chan.pid)
+    :ok = Basic.qos(chan, prefetch_count: 1)
+    {:ok, _queue} = Queue.declare(chan, queue_name, queue_opts)
+    :ok = Exchange.fanout(chan, @exchange_name, durable: true)
+    :ok = Queue.bind(chan, queue_name, @exchange_name)
+    {:ok, _consume} = Basic.consume(chan, queue_name)
+    %__MODULE__{channel: chan}
+  end
+
+  defp queue_name do
+    :medusa
+    |> Application.get_env(Medusa)
+    |> Keyword.get(:rabbitmq_queue, "")
+  end
+
+  defp queue_opts do
+    case queue_name do
+      "" -> [exclusive: true]
+      _ -> [durable: true]
+    end
+  end
+
+end

--- a/lib/medusa/adapter/rabbitmq.ex
+++ b/lib/medusa/adapter/rabbitmq.ex
@@ -43,7 +43,7 @@ defmodule Medusa.Adapter.RabbitMQ do
   def handle_call({:publish, event, payload}, _from, state) do
     Logger.debug "#{inspect __MODULE__}: [#{inspect event}]: #{inspect payload}"
     message = %Message{event: event, message: payload} |> Poison.encode!
-    AMQP.Basic.publish(state.channel, @exchange_name, "", message)
+    AMQP.Basic.publish(state.channel, @exchange_name, "", message, persistent: true)
     {:noreply, state}
   end
 

--- a/lib/medusa/adapter/rabbitmq.ex
+++ b/lib/medusa/adapter/rabbitmq.ex
@@ -44,7 +44,7 @@ defmodule Medusa.Adapter.RabbitMQ do
     Logger.debug "#{inspect __MODULE__}: [#{inspect event}]: #{inspect payload}"
     message = %Message{event: event, message: payload} |> Poison.encode!
     AMQP.Basic.publish(state.channel, @exchange_name, "", message, persistent: true)
-    {:noreply, state}
+    {:reply, :ok, state}
   end
 
   def handle_info({:basic_consume_ok, %{consumer_tag: _consumer_tag}}, state) do

--- a/lib/medusa/broker.ex
+++ b/lib/medusa/broker.ex
@@ -1,5 +1,6 @@
 defmodule Medusa.Broker do
   @moduledoc false
+  alias Medusa.Queue
 
   defmodule Message do
     defstruct body: %{}, metadata: %{}
@@ -20,6 +21,42 @@ defmodule Medusa.Broker do
     message = %Message{body: payload, metadata: metadata}
     adapter.publish(event, message)
   end
+
+  @doc """
+  Determine whether this event should be route
+  """
+  def maybe_route({route, event, payload}) do
+    f = fn -> do_maybe_route(route, event, payload) end
+    Task.Supervisor.start_child(Broker.Supervisor, f)
+  end
+
+  defp do_maybe_route(route, event, payload) do
+    if route_match?(route, event) do
+      enqueue(route, payload)
+      trigger_producer(route)
+    end
+  end
+
+  defp enqueue(route, payload) do
+    Queue.insert(route, payload)
+  end
+
+  defp trigger_producer(route) do
+    route
+    |> String.to_atom
+    |> GenServer.cast({:trigger})
+  end
+
+  defp route_match?(route, incoming)
+  when is_binary(route) and is_binary(incoming) do
+    route = String.split(route, ".")
+    incoming = String.split(incoming, ".")
+    route_match?(route, incoming)
+  end
+  defp route_match?([], []), do: true
+  defp route_match?(["*"|t1], [_|t2]), do: route_match?(t1, t2)
+  defp route_match?([h|t1], [h|t2]), do: route_match?(t1, t2)
+  defp route_match?(_, _), do: false
 
   defp adapter do
     :medusa |> Application.get_env(Medusa) |> Keyword.fetch!(:adapter)

--- a/lib/medusa/broker.ex
+++ b/lib/medusa/broker.ex
@@ -1,15 +1,8 @@
 defmodule Medusa.Broker do
   @moduledoc false
-  use GenServer
-  require Logger
 
   defmodule Message do
     defstruct body: %{}, metadata: %{}
-  end
-
-  # API
-  def start_link() do
-    GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 
   @doc """
@@ -17,7 +10,7 @@ defmodule Medusa.Broker do
   it just ignores it.
   """
   def new_route(event) do
-    broadcast get_all_members, {:new_route, event}
+    adapter.new_route(event)
   end
 
   @doc """
@@ -25,115 +18,11 @@ defmodule Medusa.Broker do
   """
   def publish(event, payload, metadata \\ %{}) do
     message = %Message{body: payload, metadata: metadata}
-    broadcast get_members, {:publish, event, message}
-  end
-
-  # Callbacks
-
-  @doc """
-  Register self into pg2 group. see `pg2_namespace/0`
-  """
-  def init(_opts) do
-    group = pg2_namespace
-    :ok = :pg2.create group
-    :ok = :pg2.join group, self
-    {:ok, MapSet.new}
-  end
-
-  def handle_call({:new_route, event}, _from, state) do
-    Logger.debug "#{inspect __MODULE__}: [#{inspect event}]"
-    {:reply, :ok, MapSet.put(state, event)}
-  end
-
-  def handle_call({:publish, event, payload}, _from, state) do
-    Logger.debug "#{inspect __MODULE__}: [#{inspect event}]: #{inspect payload}"
-    Enum.each(state, &maybe_route {&1, event, payload})
-    {:reply, :ok, state}
-  end
-
-  def handle_info({:forward_to_local, msg}, state) do
-    handle_call(msg, self, state)
-    {:noreply, state}
-  end
-
-  defp maybe_route({route, event, payload}) do
-    f = fn -> maybe_route route, event, payload end
-    Task.Supervisor.start_child Broker.Supervisor, f
-  end
-
-  defp maybe_route(route, event, payload) do
-    if route_match?(route, event) do
-      enqueue route, payload
-      trigger_producer route
-    end
-  end
-
-  defp enqueue(route, payload) do
-    adapter.insert route, payload
+    adapter.publish(event, message)
   end
 
   defp adapter do
-    Keyword.get(Application.get_env(:medusa, Medusa), :adapter)
+    :medusa |> Application.get_env(Medusa) |> Keyword.fetch!(:adapter)
   end
 
-  defp trigger_producer(route) do
-    route
-    |> String.to_atom
-    |> GenServer.cast({:trigger})
-  end
-
-  defp route_match?(route, incoming)
-  when is_binary(route) and is_binary(incoming) do
-    route = String.split route, "."
-    incoming = String.split incoming, "."
-    route_match? route, incoming
-  end
-  defp route_match?([], []), do: true
-  defp route_match?(["*"|t1], [_|t2]), do: route_match?(t1, t2)
-  defp route_match?([h|t1], [h|t2]), do: route_match?(t1, t2)
-  defp route_match?(_, _), do: false
-
-  # process group name
-  defp pg2_namespace do
-    name =
-      :medusa
-      |> Application.get_env(Medusa)
-      |> Keyword.get(:group, random_name)
-    {:medusa, name}
-  end
-
-  # random name
-  defp random_name(len \\ 32) do
-    len
-    |> :crypto.strong_rand_bytes
-    |> Base.url_encode64
-    |> binary_part(0, len)
-  end
-
-  # get all nodes in medusa
-  defp get_all_members do
-    :pg2.which_groups
-    |> Enum.filter_map(&elem(&1, 0) == :medusa, &:pg2.get_members/1)
-  end
-
-  # get all medusa groups and random one member from each group
-  defp get_members do
-    get_all_members
-    |> Enum.map(&random_member/1)
-  end
-
-  defp random_member([]), do: []
-  defp random_member([pid]), do: pid
-  defp random_member(pids) when is_list(pids), do: Enum.random pids
-
-  defp broadcast(pids, msg) when is_list(pids) do
-    pids
-    |> List.flatten
-    |> Enum.each(fn
-      pid when is_pid(pid) and node(pid) == node() ->
-        GenServer.call __MODULE__, msg
-      pid ->
-        send pid, {:forward_to_local, msg}
-    end)
-  end
 end

--- a/lib/medusa/producer.ex
+++ b/lib/medusa/producer.ex
@@ -31,6 +31,10 @@ defmodule Medusa.Producer do
     {:automatic, new_state}
   end
 
+  def handle_cancel({:down, _reason, _process}, state) do
+     {:noreply, [], state}
+  end
+
   def handle_cancel(_reason, {pid, _ref}, %{consumers: consumers} = state) do
     cond do
       MapSet.member?(consumers, pid) && MapSet.size(consumers) == 1 ->
@@ -42,6 +46,7 @@ defmodule Medusa.Producer do
         {:noreply, [], state}
     end
   end
+
   def handle_cancel(_reason, _from, state) do
     {:noreply, [], state}
   end

--- a/lib/medusa/producer.ex
+++ b/lib/medusa/producer.ex
@@ -2,6 +2,7 @@ defmodule Medusa.Producer do
   alias Experimental.GenStage
   use GenStage
   require Logger
+  alias Medusa.Queue
 
   defstruct id: nil, demand: 0, consumers: MapSet.new
 
@@ -48,14 +49,11 @@ defmodule Medusa.Producer do
   defp get_next(state) do
     Logger.debug "#{inspect __MODULE__}: #{inspect state}"
     if state.demand > 0 do
-      event = adapter.next(state.id)
+      event = Queue.next(state.id)
       Logger.debug "#{inspect __MODULE__}: event #{inspect event}"
       d = state.demand
       {:noreply, [event], %{state | demand: d - 1}}
     else {:noreply, [], state} end
   end
 
-  defp adapter do
-    Keyword.get(Application.get_env(:medusa, Medusa), :adapter)
-  end
 end

--- a/lib/medusa/producer.ex
+++ b/lib/medusa/producer.ex
@@ -31,7 +31,7 @@ defmodule Medusa.Producer do
     {:automatic, new_state}
   end
 
-  def handle_cancel({:down, _reason, _process}, state) do
+  def handle_cancel({:down, _reason, _process}, _from, state) do
      {:noreply, [], state}
   end
 

--- a/lib/medusa/queue.ex
+++ b/lib/medusa/queue.ex
@@ -1,0 +1,38 @@
+defmodule Medusa.Queue do
+  use GenServer
+  require Logger
+
+  def start_link() do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def insert(type, payload) do
+    Logger.debug "#{inspect __MODULE__}: insert #{inspect payload} on #{inspect type}"
+    GenServer.cast __MODULE__, {:insert, type, payload}
+  end
+
+  def next(type) do
+    Logger.debug "#{inspect __MODULE__}: next from #{inspect type}"
+    GenServer.call __MODULE__, {:next, type}
+  end
+
+  def init(_args) do
+    {:ok, %{}}
+  end
+
+  def handle_call({:next, type}, _from, state) do
+    case Map.get(state, type) do
+      :nil -> {:reply, [], state}
+      q ->
+        case :queue.out q do
+          {{:value, i}, q} -> {:reply, i, Map.put(state, type, q)}
+          {:empty, q} -> {:reply, [], Map.put(state, type, q)}
+        end
+    end
+  end
+
+  def handle_cast({:insert, type, payload}, state) do
+    {:noreply, Map.update(state, type, :queue.in(payload, :queue.new), fn q -> :queue.in(payload, q) end)}
+  end
+
+end

--- a/mix.exs
+++ b/mix.exs
@@ -32,6 +32,9 @@ defmodule Medusa.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [{:gen_stage, "~> 0.4.0"}]
+    [{:amqp, "~> 0.1.5"},
+     {:amqp_client, git: "https://github.com/dsrosario/amqp_client.git", branch: "erlang_otp_19", override: true},
+     {:gen_stage, "~> 0.4.0"},
+     {:poison, "~> 3.0.0"}]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -36,6 +36,6 @@ defmodule Medusa.Mixfile do
      {:amqp_client, git: "https://github.com/dsrosario/amqp_client.git", branch: "erlang_otp_19", override: true},
      {:connection, "~> 1.0.4"},
      {:gen_stage, "~> 0.4.0"},
-     {:poison, "~> 2.0.0"}]
+     {:poison, "~> 2.0"}]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -35,6 +35,6 @@ defmodule Medusa.Mixfile do
     [{:amqp, "~> 0.1.5"},
      {:amqp_client, git: "https://github.com/dsrosario/amqp_client.git", branch: "erlang_otp_19", override: true},
      {:gen_stage, "~> 0.4.0"},
-     {:poison, "~> 3.0.0"}]
+     {:poison, "~> 2.0.0"}]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -34,6 +34,7 @@ defmodule Medusa.Mixfile do
   defp deps do
     [{:amqp, "~> 0.1.5"},
      {:amqp_client, git: "https://github.com/dsrosario/amqp_client.git", branch: "erlang_otp_19", override: true},
+     {:connection, "~> 1.0.4"},
      {:gen_stage, "~> 0.4.0"},
      {:poison, "~> 2.0.0"}]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -2,5 +2,5 @@
   "amqp_client": {:git, "https://github.com/dsrosario/amqp_client.git", "3b3086534875c783803fcef7c5befaddd57a4561", [branch: "erlang_otp_19"]},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
   "gen_stage": {:hex, :gen_stage, "0.4.3", "721a82a6c3de8438435ef1970d4942865afef5befb6f318055724b171860a8b4", [:mix], []},
-  "poison": {:hex, :poison, "2.0.1", "81248a36d1b602b17ea6556bfa8952492091f01af05173de11f8b297e2bbf088", [:mix], []},
+  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
   "rabbit_common": {:git, "https://github.com/jbrisbin/rabbit_common.git", "eea16abd375981d16595d2cefaac893c7281187b", [tag: "rabbitmq-3.5.6"]}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,1 +1,5 @@
-%{"gen_stage": {:hex, :gen_stage, "0.4.3", "721a82a6c3de8438435ef1970d4942865afef5befb6f318055724b171860a8b4", [:mix], []}}
+%{"amqp": {:hex, :amqp, "0.1.5", "f38e30abfce06fd2213f5e24744a2923f9d3c30f1687db19952be547457e0e7b", [:mix], [{:amqp_client, "3.5.6", [hex: :amqp_client, optional: false]}]},
+  "amqp_client": {:git, "https://github.com/dsrosario/amqp_client.git", "3b3086534875c783803fcef7c5befaddd57a4561", [branch: "erlang_otp_19"]},
+  "gen_stage": {:hex, :gen_stage, "0.4.3", "721a82a6c3de8438435ef1970d4942865afef5befb6f318055724b171860a8b4", [:mix], []},
+  "poison": {:hex, :poison, "3.0.0", "625ebd64d33ae2e65201c2c14d6c85c27cc8b68f2d0dd37828fde9c6920dd131", [:mix], []},
+  "rabbit_common": {:git, "https://github.com/jbrisbin/rabbit_common.git", "eea16abd375981d16595d2cefaac893c7281187b", [tag: "rabbitmq-3.5.6"]}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"amqp": {:hex, :amqp, "0.1.5", "f38e30abfce06fd2213f5e24744a2923f9d3c30f1687db19952be547457e0e7b", [:mix], [{:amqp_client, "3.5.6", [hex: :amqp_client, optional: false]}]},
   "amqp_client": {:git, "https://github.com/dsrosario/amqp_client.git", "3b3086534875c783803fcef7c5befaddd57a4561", [branch: "erlang_otp_19"]},
   "gen_stage": {:hex, :gen_stage, "0.4.3", "721a82a6c3de8438435ef1970d4942865afef5befb6f318055724b171860a8b4", [:mix], []},
-  "poison": {:hex, :poison, "3.0.0", "625ebd64d33ae2e65201c2c14d6c85c27cc8b68f2d0dd37828fde9c6920dd131", [:mix], []},
+  "poison": {:hex, :poison, "2.0.1", "81248a36d1b602b17ea6556bfa8952492091f01af05173de11f8b297e2bbf088", [:mix], []},
   "rabbit_common": {:git, "https://github.com/jbrisbin/rabbit_common.git", "eea16abd375981d16595d2cefaac893c7281187b", [tag: "rabbitmq-3.5.6"]}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{"amqp": {:hex, :amqp, "0.1.5", "f38e30abfce06fd2213f5e24744a2923f9d3c30f1687db19952be547457e0e7b", [:mix], [{:amqp_client, "3.5.6", [hex: :amqp_client, optional: false]}]},
   "amqp_client": {:git, "https://github.com/dsrosario/amqp_client.git", "3b3086534875c783803fcef7c5befaddd57a4561", [branch: "erlang_otp_19"]},
+  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
   "gen_stage": {:hex, :gen_stage, "0.4.3", "721a82a6c3de8438435ef1970d4942865afef5befb6f318055724b171860a8b4", [:mix], []},
   "poison": {:hex, :poison, "2.0.1", "81248a36d1b602b17ea6556bfa8952492091f01af05173de11f8b297e2bbf088", [:mix], []},
   "rabbit_common": {:git, "https://github.com/jbrisbin/rabbit_common.git", "eea16abd375981d16595d2cefaac893c7281187b", [tag: "rabbitmq-3.5.6"]}}

--- a/test/adapter/rabbitmq_adapter_test.exs
+++ b/test/adapter/rabbitmq_adapter_test.exs
@@ -1,0 +1,37 @@
+defmodule Medusa.Adapter.RabbitMQTest do
+  use ExUnit.Case, async: true
+
+  setup do
+    {:ok, conn} = AMQP.Connection.open()
+    {:ok, chan} = AMQP.Channel.open(conn)
+    queue_name = "test_queue_name"
+    config = [
+      adapter: Medusa.Adapter.RabbitMQ,
+      RabbitMQ: [
+        connection: [
+          username: "guest",
+          password: "guest",
+          virtual_host: "/",
+          host: "localhost",
+          port: :undefined
+        ],
+        queue_name: queue_name
+      ]
+    ]
+
+    on_exit fn ->
+      Application.stop(:medusa)
+      AMQP.Queue.delete(chan, queue_name)
+      Application.ensure_all_started(:medusa)
+    end
+
+    {:ok, chan: chan, queue_name: queue_name, config: config}
+  end
+
+  test "config queue_name should crate on RabbitMQ server",
+        %{chan: chan, queue_name: queue_name, config: config} do
+    Application.put_env(:medusa, Medusa, config)
+    assert {:ok, _} = AMQP.Queue.declare(chan, queue_name, passive: true)
+  end
+
+end

--- a/test/external_integration_test.exs
+++ b/test/external_integration_test.exs
@@ -1,100 +1,239 @@
 defmodule MyModule do
   def echo(message) do
     message = put_in message, [Access.key(:metadata), :from], MyModule.Echo
-    send message.metadata.to, message
+    send(message.metadata.to, message)
   end
 
   def ping(message) do
     message = put_in message, [Access.key(:metadata), :from], MyModule.Ping
-    send message.metadata.to, message
+    send(message.metadata.to, message)
   end
+
+  def rpc(message) do
+    message = put_in message, [Access.key(:metadata), :from], MyModule.RPC
+    :self |> Process.whereis |> send(message)
+  end
+
 end
 
 defmodule ExternalIntegrationTest do
   use ExUnit.Case
   require Medusa
-
+  import Medusa.TestHelper
   alias Medusa.Broker.Message
 
-  test "Add consumers" do
-    assert {:ok, _pid} = Medusa.consume "foo.bob", &IO.puts/1
+  describe "Local Adapter" do
+
+    test "Send events" do
+      Medusa.consume "foo.bar", &MyModule.echo/1
+      Medusa.consume "foo.*", &MyModule.echo/1
+      Medusa.publish "foo.bar", 90, %{"optional_field" => "nice_to_have", to: self}
+      assert_receive %Message{body: 90,
+                              metadata: %{"optional_field" => "nice_to_have",
+                                          from: MyModule.Echo, to: _self}}, 500
+      assert_receive %Message{body: 90,
+                              metadata: %{"optional_field" => "nice_to_have",
+                                          from: MyModule.Echo, to: _self}}, 500
+    end
+
+    test "Send event to consumer with bind_once: true.
+          consumer and producer should die" do
+      assert {:ok, consumer} = Medusa.consume("you.me", &MyModule.echo/1, bind_once: true)
+      assert Process.alive?(consumer)
+      producer = Process.whereis(:"you.me")
+      assert Process.alive?(producer)
+      ref_consumer = Process.monitor(consumer)
+      ref_producer = Process.monitor(producer)
+      Medusa.publish("you.me", 100, %{to: self})
+      assert_receive %Message{body: 100, metadata: %{to: _self, from: MyModule.Echo}}, 500
+      assert_receive {:DOWN, ^ref_consumer, :process, _, :normal}
+      assert_receive {:DOWN, ^ref_producer, :process, _, :normal}
+    end
+
+    test "Send event to consumer with bind_once: true in already exists route
+          So producer is shared with others then it should not die" do
+      assert {:ok, con1} = Medusa.consume("me.you", &MyModule.ping/1)
+      assert {:ok, con2} = Medusa.consume("me.you", &MyModule.echo/1, bind_once: true)
+      assert Process.alive?(con1)
+      assert Process.alive?(con2)
+      producer = Process.whereis(:"me.you")
+      assert Process.alive?(producer)
+      ref_con1 = Process.monitor(con1)
+      ref_con2 = Process.monitor(con2)
+      ref_prod = Process.monitor(producer)
+      Medusa.publish("me.you", 1000, %{to: self})
+      assert_receive %Message{body: 1000, metadata: %{to: _self, from: MyModule.Echo}}, 500
+      assert_receive %Message{body: 1000, metadata: %{to: _self, from: MyModule.Ping}}, 500
+      refute_receive {:DOWN, ^ref_con1, :process, _, :normal}
+      assert_receive {:DOWN, ^ref_con2, :process, _, :normal}
+      refute_receive {:DOWN, ^ref_prod, :process, _, :normal}
+    end
+
+    test "Send event to consumer with bind_once: true and then
+          start consume with long-running consumer, producer should survive" do
+      assert {:ok, con1} = Medusa.consume("he.she", &MyModule.echo/1, bind_once: true)
+      assert {:ok, con2} = Medusa.consume("he.she", &MyModule.ping/1)
+      assert Process.alive?(con1)
+      assert Process.alive?(con2)
+      producer = Process.whereis(:"he.she")
+      assert Process.alive?(producer)
+      ref_con1 = Process.monitor(con1)
+      ref_con2 = Process.monitor(con2)
+      ref_prod = Process.monitor(producer)
+      Medusa.publish("he.she", 1, %{to: self})
+      assert_receive %Message{body: 1, metadata: %{to: _self, from: MyModule.Echo}}, 500
+      assert_receive %Message{body: 1, metadata: %{to: _self, from: MyModule.Ping}}, 500
+      assert_receive {:DOWN, ^ref_con1, :process, _, :normal}
+      refute_receive {:DOWN, ^ref_con2, :process, _, :normal}
+      refute_receive {:DOWN, ^ref_prod, :process, _, :normal}
+    end
+
   end
 
-  test "Add invalid consumer" do
-    assert_raise MatchError, ~r/arity/, fn -> Medusa.consume "foo.bob", fn -> IO.puts("blah") end end
+
+  describe "PG2 Adapter" do
+    setup do
+      Application.put_env(:medusa, Medusa, [adapter: Medusa.Adapter.PG2], persistent: false)
+      restart_app()
+      Medusa.Cluster.spawn
+      {:ok, node1: :'node1@127.0.0.1', node2: :'node2@127.0.0.1'}
+    end
+
+    @tag :pg2
+    test "Sent events", %{node1: node1, node2: node2} do
+      Medusa.consume("pg", &MyModule.echo/1)
+      :rpc.call(node1, Medusa, :publish, ["pg", "ICANFLY", %{to: self}])
+      :rpc.call(node2, Medusa, :publish, ["pg", "YOUSEEME", %{to: self}])
+      assert_receive %Message{body: "ICANFLY", metadata: %{to: _, from: MyModule.Echo}}, 500
+      assert_receive %Message{body: "YOUSEEME", metadata: %{to: _, from: MyModule.Echo}}, 500
+    end
+
+    @tag :pg2
+    test "Send event to consumer with bind_once: true.
+          consumer and producer should die", %{node1: node1} do
+      assert {:ok, consumer} = Medusa.consume("pg.1", &MyModule.echo/1, bind_once: true)
+      assert Process.alive?(consumer)
+      producer = Process.whereis(:"pg.1")
+      assert Process.alive?(producer)
+      ref_consumer = Process.monitor(consumer)
+      ref_producer = Process.monitor(producer)
+      :rpc.call(node1, Medusa, :publish, ["pg.1", "HOLA", %{to: self}])
+      assert_receive %Message{body: "HOLA", metadata: %{to: _, from: MyModule.Echo}}, 500
+      assert_receive {:DOWN, ^ref_consumer, :process, _, :normal}
+      assert_receive {:DOWN, ^ref_producer, :process, _, :normal}
+    end
+
+    @tag :pg2
+    test "Send event to consumer with bind_once: true in already exists route
+          So producer is shared with others then it should not die", %{node1: node1} do
+      assert {:ok, con1} = Medusa.consume("pg.2", &MyModule.ping/1)
+      assert {:ok, con2} = Medusa.consume("pg.2", &MyModule.echo/1, bind_once: true)
+      assert Process.alive?(con1)
+      assert Process.alive?(con2)
+      producer = Process.whereis(:"pg.2")
+      assert Process.alive?(producer)
+      ref_con1 = Process.monitor(con1)
+      ref_con2 = Process.monitor(con2)
+      ref_prod = Process.monitor(producer)
+      :rpc.call(node1, Medusa, :publish, ["pg.2", "GRACIAS", %{to: self}])
+      assert_receive %Message{body: "GRACIAS", metadata: %{to: _self, from: MyModule.Echo}}, 500
+      assert_receive %Message{body: "GRACIAS", metadata: %{to: _self, from: MyModule.Ping}}, 500
+      refute_receive {:DOWN, ^ref_con1, :process, _, :normal}
+      assert_receive {:DOWN, ^ref_con2, :process, _, :normal}
+      refute_receive {:DOWN, ^ref_prod, :process, _, :normal}
+    end
+
+    @tag :pg2
+    test "Send event to consumer with bind_once: true and then
+          start consume with long-running consumer, producer should survive", %{node1: node1} do
+      assert {:ok, con1} = Medusa.consume("pg.3", &MyModule.echo/1, bind_once: true)
+      assert {:ok, con2} = Medusa.consume("pg.3", &MyModule.ping/1)
+      assert Process.alive?(con1)
+      assert Process.alive?(con2)
+      producer = Process.whereis(:"pg.3")
+      assert Process.alive?(producer)
+      ref_con1 = Process.monitor(con1)
+      ref_con2 = Process.monitor(con2)
+      ref_prod = Process.monitor(producer)
+      :rpc.call(node1, Medusa, :publish, ["pg.3", "ADIOS", %{to: self}])
+      assert_receive %Message{body: "ADIOS", metadata: %{to: _self, from: MyModule.Echo}}, 500
+      assert_receive %Message{body: "ADIOS", metadata: %{to: _self, from: MyModule.Ping}}, 500
+      assert_receive {:DOWN, ^ref_con1, :process, _, :normal}
+      refute_receive {:DOWN, ^ref_con2, :process, _, :normal}
+      refute_receive {:DOWN, ^ref_prod, :process, _, :normal}
+    end
   end
 
-  test "Send events" do
-    Process.register self, :test
-    Medusa.consume "foo.bar", &MyModule.echo/1
-    Medusa.consume "foo.*", &MyModule.echo/1
+  describe "RabbitMQ Adapter" do
+    setup do
+      import Supervisor.Spec, warn: false
+      Application.put_env(:medusa, Medusa, [adapter: Medusa.Adapter.RabbitMQ])
+      Supervisor.start_child(Medusa.Supervisor, worker(Medusa.Adapter.RabbitMQ, []))
+      Process.register(self, :self)
+      :ok
+    end
 
-    Medusa.publish "foo.bar", 90, %{"optional_field" => "nice_to_have", to: self}
+    @tag :rabbitmq
+    test "sent events" do
+      Medusa.consume("rabbitmq", &MyModule.rpc/1)
+      spawn fn -> Medusa.publish("rabbitmq", "RABBIT!") end
+      assert_receive %Message{body: "RABBIT!", metadata: %{from: MyModule.RPC}}, 500
+    end
 
-    # We should receive two because of the routes setup.
-    assert_receive %Message{body: 90, metadata: %{"optional_field" => "nice_to_have", from: MyModule.Echo, to: _self}}, 500
-    assert_receive %Message{body: 90, metadata: %{"optional_field" => "nice_to_have", from: MyModule.Echo, to: _self}}, 500
-  end
+    @tag :rabbitmq
+    test "Send event to consumer with bind_once: true.
+          consumer and producer should die" do
+      assert {:ok, consumer} = Medusa.consume("rabbitmq.1", &MyModule.rpc/1, bind_once: true)
+      assert Process.alive?(consumer)
+      producer = Process.whereis(:"rabbitmq.1")
+      assert Process.alive?(producer)
+      ref_consumer = Process.monitor(consumer)
+      ref_producer = Process.monitor(producer)
+      spawn fn -> Medusa.publish("rabbitmq.1", "HOLA") end
+      assert_receive %Message{body: "HOLA", metadata: %{from: MyModule.RPC}}, 500
+      assert_receive {:DOWN, ^ref_consumer, :process, _, :normal}
+      assert_receive {:DOWN, ^ref_producer, :process, _, :normal}
+    end
 
-  test "Send event to consumer with bind_once: true.
-        consumer and producer should die" do
-    assert {:ok, pid} = Medusa.consume "you.me", &MyModule.echo/1, bind_once: true
-    producer = Process.whereis(:"you.me")
-    assert Process.alive?(pid)
-    assert producer
-    Medusa.publish "you.me", 100, %{to: self}
-    assert_receive %Message{body: 100, metadata: %{to: _self, from: MyModule.Echo}}, 500
-    Process.sleep(10) # wait producer and consumer die
-    refute Process.alive?(pid)
-    refute Process.alive?(producer)
-  end
+    @tag :rabbitmq
+    test "Send event to consumer with bind_once: true in already exists route
+          So producer is shared with others then it should not die" do
+      assert {:ok, con1} = Medusa.consume("rabbitmq.2", &MyModule.rpc/1)
+      assert {:ok, con2} = Medusa.consume("rabbitmq.2", &MyModule.rpc/1, bind_once: true)
+      assert Process.alive?(con1)
+      assert Process.alive?(con2)
+      producer = Process.whereis(:"rabbitmq.2")
+      assert Process.alive?(producer)
+      ref_con1 = Process.monitor(con1)
+      ref_con2 = Process.monitor(con2)
+      ref_prod = Process.monitor(producer)
+      spawn fn -> Medusa.publish("rabbitmq.2", "GRACIAS") end
+      assert_receive %Message{body: "GRACIAS", metadata: %{from: MyModule.RPC}}, 500
+      assert_receive %Message{body: "GRACIAS", metadata: %{from: MyModule.RPC}}, 500
+      refute_receive {:DOWN, ^ref_con1, :process, _, :normal}
+      assert_receive {:DOWN, ^ref_con2, :process, _, :normal}
+      refute_receive {:DOWN, ^ref_prod, :process, _, :normal}
+    end
 
-  test "Send event to consumer with bind_once: true in already exists route
-        So producer is shared with others then it should not die" do
-    assert {:ok, pid1} = Medusa.consume "me.you", &MyModule.ping/1
-    assert {:ok, pid2} = Medusa.consume "me.you", &MyModule.echo/1, bind_once: true
-    producer = Process.whereis(:"me.you")
-    assert Process.alive?(pid1)
-    assert Process.alive?(pid2)
-    assert producer
-    Medusa.publish "me.you", 1000, %{to: self}
-    assert_receive %Message{body: 1000, metadata: %{to: _self, from: MyModule.Echo}}, 500
-    assert_receive %Message{body: 1000, metadata: %{to: _self, from: MyModule.Ping}}, 500
-    Process.sleep(10) # wait consumer bind_once die
-    assert Process.alive?(pid1)
-    refute Process.alive?(pid2)
-    assert Process.alive?(producer)
-  end
-
-  test "Send event to consumer with bind_once: true and then
-        start consume with long-running consumer, producer should survive" do
-    assert {:ok, pid1} = Medusa.consume "he.she", &MyModule.echo/1, bind_once: true
-    assert {:ok, pid2} = Medusa.consume "he.she", &MyModule.ping/1
-    assert Process.alive?(pid1)
-    assert Process.alive?(pid2)
-    producer = Process.whereis(:"he.she")
-    Medusa.publish "he.she", 1, %{to: self}
-    assert_receive %Message{body: 1, metadata: %{to: _self, from: MyModule.Echo}}, 500
-    assert_receive %Message{body: 1, metadata: %{to: _self, from: MyModule.Ping}}, 500
-    Process.sleep(10) # wait consumer bind_once die
-    refute Process.alive?(pid1)
-    assert Process.alive?(pid2)
-    assert Process.alive?(producer)
-  end
-
-  @tag :pg2
-  test "pg2 clustered" do
-    Application.put_env(:medusa, Medusa, [adapter: Medusa.Adapter.PG2], persistent: true)
-    Application.stop(:medusa)
-    Application.ensure_all_started(:medusa)
-    Medusa.Cluster.spawn
-    node1 = :'node1@127.0.0.1'
-    node2 = :'node2@127.0.0.1'
-    Medusa.consume "clustered", &MyModule.echo/1
-    :rpc.call(node1, Medusa, :publish, ["clustered", "ICANFLY", %{to: self}])
-    :rpc.call(node2, Medusa, :publish, ["clustered", "YOUSEEME", %{to: self}])
-    assert_receive %Message{body: "ICANFLY", metadata: %{to: _, from: MyModule.Echo}}, 500
-    assert_receive %Message{body: "YOUSEEME", metadata: %{to: _, from: MyModule.Echo}}, 500
+    @tag :rabbitmq
+    test "Send event to consumer with bind_once: true and then
+          start consume with long-running consumer, producer should survive" do
+      assert {:ok, con1} = Medusa.consume("rabbitmq.3", &MyModule.rpc/1, bind_once: true)
+      assert {:ok, con2} = Medusa.consume("rabbitmq.3", &MyModule.rpc/1)
+      assert Process.alive?(con1)
+      assert Process.alive?(con2)
+      producer = Process.whereis(:"rabbitmq.3")
+      assert Process.alive?(producer)
+      ref_con1 = Process.monitor(con1)
+      ref_con2 = Process.monitor(con2)
+      ref_prod = Process.monitor(producer)
+      spawn fn -> Medusa.publish("rabbitmq.3", "ADIOS") end
+      assert_receive %Message{body: "ADIOS", metadata: %{from: MyModule.RPC}}, 500
+      assert_receive %Message{body: "ADIOS", metadata: %{from: MyModule.RPC}}, 500
+      assert_receive {:DOWN, ^ref_con1, :process, _, :normal}
+      refute_receive {:DOWN, ^ref_con2, :process, _, :normal}
+      refute_receive {:DOWN, ^ref_prod, :process, _, :normal}
+    end
   end
 
 end

--- a/test/external_integration_test.exs
+++ b/test/external_integration_test.exs
@@ -82,8 +82,12 @@ defmodule ExternalIntegrationTest do
     assert Process.alive?(producer)
   end
 
-  @tag :clustered
-  test "clustered" do
+  @tag :pg2
+  test "pg2 clustered" do
+    Application.put_env(:medusa, Medusa, [adapter: Medusa.Adapter.PG2], persistent: true)
+    Application.stop(:medusa)
+    Application.ensure_all_started(:medusa)
+    Medusa.Cluster.spawn
     node1 = :'node1@127.0.0.1'
     node2 = :'node2@127.0.0.1'
     Medusa.consume "clustered", &MyModule.echo/1

--- a/test/medusa_test.exs
+++ b/test/medusa_test.exs
@@ -1,11 +1,7 @@
 defmodule MedusaTest do
   use ExUnit.Case
+  import Medusa.TestHelper
   doctest Medusa
-
-  defp restart_app do
-    Application.stop(:medusa)
-    Application.ensure_all_started(:medusa)
-  end
 
   test "not config should fallback to default" do
     Application.delete_env(:medusa, Medusa, persistent: true)
@@ -19,6 +15,15 @@ defmodule MedusaTest do
     restart_app()
     assert Application.get_env(:medusa, Medusa) ==
       [adapter: Medusa.Adapter.Local]
+  end
+
+  test "Add consumers" do
+    assert {:ok, _pid} = Medusa.consume("foo.bob", &IO.puts/1)
+  end
+
+  test "Add invalid consumer" do
+    assert_raise MatchError, ~r/arity/,
+      fn -> Medusa.consume("foo.bob", fn -> IO.puts("blah") end) end
   end
 
 end

--- a/test/medusa_test.exs
+++ b/test/medusa_test.exs
@@ -2,7 +2,23 @@ defmodule MedusaTest do
   use ExUnit.Case
   doctest Medusa
 
-  test "the truth" do
-    assert 1 + 1 == 2
+  defp restart_app do
+    Application.stop(:medusa)
+    Application.ensure_all_started(:medusa)
   end
+
+  test "not config should fallback to default" do
+    Application.delete_env(:medusa, Medusa, persistent: true)
+    restart_app()
+    assert Application.get_env(:medusa, Medusa) ==
+      [adapter: Medusa.Adapter.Local]
+  end
+
+  test "config invalid adapter should fallback to Local" do
+    Application.put_env(:medusa, Medusa, [adapter: Wrong], persistent: true)
+    restart_app()
+    assert Application.get_env(:medusa, Medusa) ==
+      [adapter: Medusa.Adapter.Local]
+  end
+
 end

--- a/test/medusa_test.exs
+++ b/test/medusa_test.exs
@@ -1,18 +1,19 @@
 defmodule MedusaTest do
   use ExUnit.Case
-  import Medusa.TestHelper
   doctest Medusa
 
   test "not config should fallback to default" do
     Application.delete_env(:medusa, Medusa, persistent: true)
-    restart_app()
+    Application.stop(:medusa)
+    Application.ensure_all_started(:medusa)
     assert Application.get_env(:medusa, Medusa) ==
       [adapter: Medusa.Adapter.Local]
   end
 
   test "config invalid adapter should fallback to Local" do
     Application.put_env(:medusa, Medusa, [adapter: Wrong], persistent: true)
-    restart_app()
+    Application.stop(:medusa)
+    Application.ensure_all_started(:medusa)
     assert Application.get_env(:medusa, Medusa) ==
       [adapter: Medusa.Adapter.Local]
   end

--- a/test/support/cluster.ex
+++ b/test/support/cluster.ex
@@ -16,7 +16,11 @@ defmodule Medusa.Cluster do
   end
 
   defp spawn_node(node_host) do
-    {:ok, node} = :slave.start(to_char_list("127.0.0.1"), node_name(node_host), inet_loader_args())
+    node =
+      case :slave.start(to_char_list("127.0.0.1"), node_name(node_host), inet_loader_args()) do
+        {:ok, node} -> node
+        {:error, {:already_running, node}} -> node
+      end
     add_code_paths(node)
     transfer_configuration(node)
     ensure_applications_started(node)

--- a/test/support/test_helper.ex
+++ b/test/support/test_helper.ex
@@ -1,0 +1,10 @@
+defmodule Medusa.TestHelper do
+  @moduledoc false
+
+  def put_adapter_config(adapter) do
+    import Supervisor.Spec, warn: false
+    Application.put_env(:medusa, Medusa, [adapter: adapter])
+    Supervisor.start_child(Medusa.Supervisor, worker(adapter, []))
+  end
+
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,3 @@
-ExUnit.configure(exclude: [pg2: true])
+ExUnit.configure(exclude: [rabbitmq: true])
 
 ExUnit.start

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,7 +1,3 @@
-ExUnit.configure(exclude: [clustered: true])
-
-exclude = Keyword.get(ExUnit.configuration(), :exclude, [])
-
-unless :clustered in exclude, do: Medusa.Cluster.spawn
+ExUnit.configure(exclude: [pg2: true])
 
 ExUnit.start


### PR DESCRIPTION
add RabbitMQ as Broker Adapter

- change Broker to be Adapter.
- Organize Adapter. now have 3 adapters **Local**, **PG2**, **RabbitMQ**
- Local queue is not adapter (use in every adapters).