### PR TITLE
A healthcheck that doesn't queue messages

### DIFF
--- a/test/adapter/rabbitmq_adapter_test.exs
+++ b/test/adapter/rabbitmq_adapter_test.exs
@@ -126,19 +126,17 @@ defmodule Medusa.Adapter.RabbitMQTest do
     end
 
     test "connectivity to host timing out with alive?" do
-      config = Application.get_env(:medusa, Medusa)
-      # TEST-NET ip from RFC 5737, shouldn't be routable
-      Application.put_env(:medusa, Medusa, invalid_config "192.0.2.0")
+      put_rabbitmq_adapter_config(invalid_config "192.0.2.0")
+      :timer.sleep 1_000
       refute Medusa.alive?()
-      Application.put_env(:medusa, Medusa, config)
+      put_rabbitmq_adapter_config()
     end
 
     test "connectivity to invalid host with alive?" do
-      config = Application.get_env(:medusa, Medusa)
-      # Invalid TLD from RFC 2606
-      Application.put_env(:medusa, Medusa, invalid_config "rabbitmq.invalid")
+      put_rabbitmq_adapter_config(invalid_config "rabbitmq.invalid")
+      :timer.sleep 1_000
       refute Medusa.alive?()
-      Application.put_env(:medusa, Medusa, config)
+      put_rabbitmq_adapter_config()
     end
   end
 

--- a/test/support/test_helper.ex
+++ b/test/support/test_helper.ex
@@ -22,7 +22,6 @@ defmodule Medusa.TestHelper do
   end
 
   def put_rabbitmq_adapter_config do
-    import Supervisor.Spec, warn: false
     opts = [
       adapter: Medusa.Adapter.RabbitMQ,
       group: "test-rabbitmq",
@@ -42,6 +41,10 @@ defmodule Medusa.TestHelper do
         virtual_host: System.get_env("RABBITMQ_VIRTUAL_HOST") || "/",
         heartbeat: 10,
       ]}]
+    put_rabbitmq_adapter_config(opts)
+  end
+  def put_rabbitmq_adapter_config(opts) do
+    import Supervisor.Spec, warn: false
     Application.put_env(:medusa, Medusa, opts, persistent: true)
     restart_app()
     opts


### PR DESCRIPTION
Instead of using the admin health endpoint (which enqueues a message) instead rely on the processes managing the connection and channel to check whether everything is alive
